### PR TITLE
Add the window-manager to the API

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -188,5 +188,6 @@ export declare namespace Plugin {
         process: Process;
         statusBar: StatusBar;
         workspace: Workspace;
+        windows: IWindowManager;
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oni-api",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Oni's API layer",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -240,5 +240,6 @@ export namespace Plugin {
         process: Process
         statusBar: StatusBar
         workspace: Workspace
+        windows: IWindowManager
     }
 }


### PR DESCRIPTION
Exposes `WindowManager` in the API.
Needed for `oni-markdown-preview` in order to open and close window-splits.