### PR TITLE
remove priority parameter from statusbar typing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -152,7 +152,7 @@ export interface Log {
 
 export interface StatusBar {
     getItem(globalId?: string): StatusBarItem
-    createItem(alignment: number, priority: number, globalId?: string): StatusBarItem
+    createItem(alignment: number, globalId?: string): StatusBarItem
 }
 
 export interface Process {


### PR DESCRIPTION
Relates to onivim/oni#1114, removes priority from being explicitly passed in, inline with an API change to use config going forward