### PR TITLE
API: Add commands API off of Oni object

### DIFF
--- a/src/Commands.ts
+++ b/src/Commands.ts
@@ -1,0 +1,24 @@
+/**
+ * Commands.ts
+ *
+ * API surface area for registering and executing commands
+ */
+
+export type CommandCallback = (args?: any) => any
+export type CommandEnabledCallback = () => boolean
+
+export interface ICommand {
+    command: string
+    name: string
+    detail: string
+    enabled?: CommandEnabledCallback
+    messageSuccess?: string
+    messageFail?: string
+    execute: CommandCallback
+}
+
+export interface Api {
+    registerCommand(command: ICommand): void
+    unregisterCommand(commandName: string): void
+    executeCommand(name: string, args?: any): boolean | void
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ import * as types from "vscode-languageserver-types"
 
 import { Event, IEvent } from "oni-types"
 
+import * as Commands from "./Commands"
+
 export type DisposeFunction = () => void
 
 export interface IToken {
@@ -125,23 +127,6 @@ export interface EditorBufferEventArgs {
     filePath: string
 }
 
-export type ICommandCallback = (args?: any) => any
-export type ICommandEnabledCallback = () => boolean
-
-export interface ICommand {
-    command: string
-    name: string
-    detail: string
-    enabled?: ICommandEnabledCallback
-    messageSuccess?: string
-    messageFail?: string
-    execute: ICommandCallback
-}
-
-export interface Commands {
-    registerCommand(command: ICommand): void
-}
-
 export interface Log {
     verbose(msg: string): void
     info(msg: string): void
@@ -233,6 +218,7 @@ export namespace Plugin {
 
     export interface Api extends EventEmitter {
         automation: Automation.Api
+        commands: Commands.Api
         configuration: Configuration
         contextMenu: any /* TODO */
         diagnostics: Diagnostics.Api


### PR DESCRIPTION
This documents the `commands` API that is already available off of the Oni API object, implemented by `CommandManager`.