### PR TITLE
Add the Plugin Manager to the API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "oni-api",
-  "version": "0.0.26",
+  "version": "0.0.31",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oni-api",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "description": "Oni's API layer",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,6 +102,11 @@ export interface InputManager {
     unbindAll(): void
 }
 
+export interface IPluginManager {
+    getPlugin(name: string): any
+    loaded: boolean
+}
+
 /**
  * Automation API definition
  *
@@ -425,6 +430,7 @@ export namespace Plugin {
         input: InputManager
         language: any /* TODO */
         log: any /* TODO */
+        plugins: IPluginManager
         menu: Menu.Api
         process: Process
         statusBar: StatusBar


### PR DESCRIPTION
As suggested by the title, adding the plugin manager to the API.
It is already implemented by Oni.
Will Make Oni's API implementor class to implement this interface explicitly as well.