### PR TITLE
Editor API: Introduce 'anyEditor' concept

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oni-api",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "description": "Oni's API layer",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,8 +91,29 @@ export interface IWindowSplit {
 }
 
 export interface EditorManager {
-    allEditors: Editor
+
+    /**
+     * An array of all available `Editor` instances
+     */
+    allEditors: Editor[]
+
+    /**
+     * A proxy that _always_ points to the active `Editor`. This means
+     * you can avoid always needing to hook/unhook events when the
+     * active `Editor` changes by hooking events on `anyEditor`
+     */
+    anyEditor: Editor
+
+    /**
+     * The currently active `Editor` instance
+     */
     activeEditor: Editor
+
+    /**
+     * Event that is dispatched when the active `Editor` changes,
+     * for example, when focus moves from one `Editor` to another.
+     */
+    onActiveEditorChanged: IEvent<Editor>
 }
 
 export interface InputManager {


### PR DESCRIPTION
Much of Oni's integration with the `activeEditor` assumes that we _only_ ever have a single instance of `activeEditor` around. This will be broken by the editor multiplexing work.

One inconvenience that this introduces is that, today, we listen for a lot of events off of the current editor, like:
```
Oni.editors.activeEditor.onBufferSaved.subscribe(() => ...)
```

It becomes _really_ inconvenient if, in all those cases, we have to listen for when the editor changes, and unhook / resubscribe. The `anyEditor` does that implicitly under the hood, so for places in the code that don't care about the editor specifics, just that an event occurred, it will make sense to subscribe to `anyEditor`.