### PR TITLE
Editor: Add methods for setting tab/spaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oni-api",
-  "version": "0.0.44",
+  "version": "0.0.45",
   "description": "Oni's API layer",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -411,6 +411,18 @@ export interface BufferLayerRenderContext {
 
 export type InputCallbackFunction = (input: string) => Promise<void>
 
+export type EditorTextOptions {
+    /**
+     * Whether or not spaces should be inserted for tab characters
+     */
+    insertSpacesForTab: boolean
+
+    /**
+     * Size of tabs, in characters
+     */
+    tabSize: number
+}
+
 export interface Editor {
     mode: string
 
@@ -434,16 +446,7 @@ export interface Editor {
 
     getBuffers(): Array<Buffer | InactiveBuffer>
 
-    /**
-     * Sets whether or not space characters should be inserted when pressing tab.
-     */
-    setInsertSpacesForTab(shouldInsertSpacesForTab: boolean): void
-
-    /**
-     * Sets the size of a tab. If `setInsertSpaces` is `false`, this is the display size of the tab.
-     * If `setInsertSpaces` is `true`, this will insert the corresponding number of spaces on tab press.
-     */
-    setTabSize(tabSize: number): void
+    setTextOptions(textOptions: EditorTextOptions): Promise<void>
 
     onBufferEnter: IEvent<EditorBufferEventArgs>
     onBufferLeave: IEvent<EditorBufferEventArgs>

--- a/src/index.ts
+++ b/src/index.ts
@@ -437,7 +437,7 @@ export interface Editor {
     /**
      * Sets whether or not space characters should be inserted when pressing tab.
      */
-    setInsertSpaces(shouldInsertSpacesForTab: boolean): void
+    setInsertSpacesForTab(shouldInsertSpacesForTab: boolean): void
 
     /**
      * Sets the size of a tab. If `setInsertSpaces` is `false`, this is the display size of the tab.

--- a/src/index.ts
+++ b/src/index.ts
@@ -411,7 +411,7 @@ export interface BufferLayerRenderContext {
 
 export type InputCallbackFunction = (input: string) => Promise<void>
 
-export type EditorTextOptions {
+export type EditorTextOptions = {
     /**
      * Whether or not spaces should be inserted for tab characters
      */

--- a/src/index.ts
+++ b/src/index.ts
@@ -434,6 +434,17 @@ export interface Editor {
 
     getBuffers(): Array<Buffer | InactiveBuffer>
 
+    /**
+     * Sets whether or not space characters should be inserted when pressing tab.
+     */
+    setInsertSpaces(shouldInsertSpacesForTab: boolean): void
+
+    /**
+     * Sets the size of a tab. If `setInsertSpaces` is `false`, this is the display size of the tab.
+     * If `setInsertSpaces` is `true`, this will insert the corresponding number of spaces on tab press.
+     */
+    setTabSize(tabSize: number): void
+
     onBufferEnter: IEvent<EditorBufferEventArgs>
     onBufferLeave: IEvent<EditorBufferEventArgs>
     onBufferChanged: IEvent<EditorBufferChangedEventArgs>


### PR DESCRIPTION
This adds two new methods to the `Editor` API:
- `setInsertSpacesForTab(bool)` - sets whether or not we should insert spaces for tabs
- `setTabSize(number)` - number of spaces to insert / spaces to show for tabs

If these aren't set, they'll default to whatever the editor strategy uses (for Neovim, whatever the default or init vim settings are).