### PR TITLE
Added activeSplit and focusSplit to the API.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -152,11 +152,16 @@ export interface IWindowManager {
     // at the boundaries, when there is no further split
     onUnhandledMove: IEvent<Direction>
 
+    activeSplit: IAugmentedSplitInfo
+
     // Create a split on the editor surface
     // If direction is 'left', 'right', 'down', or 'up', the split
     // will be created in a dock. Otherwise, it will be in the primary
     // editor surface.
     createSplit(direction: Direction | SplitDirection, split: IWindowSplit): WindowSplitHandle
+
+    // Focus the given split.
+    focusSplit(splitId: string): void
 
     // Moves from the currently focused split to another focused split
     move(direction: Direction): void
@@ -165,6 +170,18 @@ export interface IWindowManager {
 export interface IWindowSplit {
     render(): JSX.Element
 }
+
+export interface IAugmentedSplitInfo extends IWindowSplit {
+    // Internal bookkeeping
+    id: string
+
+    innerSplit: IWindowSplit
+
+    // Potential API methods
+    enter?(): void
+    leave?(): void
+}
+
 
 export enum FileOpenMode {
     // Open file in existing editor / tab, if it is already open.

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,7 +152,7 @@ export interface IWindowManager {
     // at the boundaries, when there is no further split
     onUnhandledMove: IEvent<Direction>
 
-    activeSplit: IAugmentedSplitInfo
+    activeSplitHandle: WindowSplitHandle
 
     // Create a split on the editor surface
     // If direction is 'left', 'right', 'down', or 'up', the split
@@ -170,18 +170,6 @@ export interface IWindowManager {
 export interface IWindowSplit {
     render(): JSX.Element
 }
-
-export interface IAugmentedSplitInfo extends IWindowSplit {
-    // Internal bookkeeping
-    id: string
-
-    innerSplit: IWindowSplit
-
-    // Potential API methods
-    enter?(): void
-    leave?(): void
-}
-
 
 export enum FileOpenMode {
     // Open file in existing editor / tab, if it is already open.


### PR DESCRIPTION
Needed for my Markdown changes PR over in the main repo.

~~I'm not sure if bringing over `IAugmentedSplitInfo` into the API makes the most sense, so any comments on that are welcome. At the moment, its defined in both the main repo and the API, so if it makes sense here, I need to update my other PR to remove all copies of it and use the API version instead.~~

Fixed after Discord comments.
Does it make sense to keep `focusSplit` around now?