### PR TITLE
Move-in oni-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,16 +24,12 @@
   },
   "homepage": "https://github.com/onivim/oni-api#readme",
   "peerDependencies": {
-    "oni-types": "^0.0.4",
-    "vscode-languageserver-types": "^3.5.0",
-    "typescript": "^2.5.3",
-    "rimraf": "^2.6.2"
+    "vscode-languageserver-types": "^3.5.0"
   },
   "devDependencies": {
     "@types/node": "^8.0.53",
     "@types/react": "^16.0.23",
-    "oni-types": "0.0.8",
-    "rimraf": "2.6.2",
+    "rimraf": "^2.6.2",
     "rxjs": "^5.5.0",
     "typedoc": "^0.10.0",
     "typescript": "2.5.3",

--- a/src/Event.ts
+++ b/src/Event.ts
@@ -1,0 +1,37 @@
+import { EventEmitter } from "events"
+
+export interface IDisposable {
+    dispose(): void
+}
+
+export type DisposeFunction = () => void
+
+export type EventCallback<T> = (value: T) => void
+
+export interface IEvent<T> {
+    subscribe(callback: EventCallback<T>): IDisposable
+}
+
+export class Event<T> implements IEvent<T> {
+
+    private _name: string
+    private _eventObject: EventEmitter = new EventEmitter()
+
+    constructor(name?: string) {
+        this._name = name || "default_event"
+    }
+
+    public subscribe(callback: EventCallback<T>): IDisposable {
+        this._eventObject.addListener(this._name, callback)
+
+        const dispose = () => {
+            this._eventObject.removeListener(this._name, callback)
+        }
+
+        return { dispose }
+    }
+
+    public dispatch(val?: T): void {
+        this._eventObject.emit(this._name, val)
+    }
+}

--- a/src/Search.ts
+++ b/src/Search.ts
@@ -1,4 +1,4 @@
-import { IEvent } from "oni-types"
+import { IEvent } from "./Event"
 
 export interface ResultItem {
     fileName: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import * as ChildProcess from "child_process"
 
 import * as types from "vscode-languageserver-types"
 
-import { Event, IEvent } from "oni-types"
+import { Event, IEvent } from "./Event"
 
 import * as Search from "./Search"
 import * as Ui from "./Ui"
@@ -10,6 +10,8 @@ import * as Ui from "./Ui"
 export {
     Search,
     Ui,
+    IEvent,
+    Event,
 }
 
 export type DisposeFunction = () => void


### PR DESCRIPTION
Since `oni-types` is so slim *and* used now, I think it make sense to merge them.
Is that well? (will follow a PR in `Oni` if accepted)